### PR TITLE
Update friendly.yml to exclude random enemy_damage

### DIFF
--- a/weights/friendly.yaml
+++ b/weights/friendly.yaml
@@ -82,8 +82,8 @@ item_functionality:
   expert: 0
 enemy_damage:
   default: 80
-  shuffled: 10
-  random: 10
+  shuffled: 20
+  random: 0
 enemy_health:
   default: 80
   easy: 10


### PR DESCRIPTION
Per the website--and personal experience--this can result in a full cast of high damage enemies.
Extra weight is given to the "shuffled" value instead.