### PR TITLE
Update vanilla.yaml

### DIFF
--- a/presets/alttpr/vanilla.yaml
+++ b/presets/alttpr/vanilla.yaml
@@ -384,7 +384,7 @@ settings:
     SHlwZSBDYXZlIC0gQm90dG9tOjE=: TwentyRupees:1
     SHlwZSBDYXZlIC0gTWlkZGxlIExlZnQ6MQ==: TwentyRupees:1
     SHlwZSBDYXZlIC0gTWlkZGxlIFJpZ2h0OjE=: TwentyRupees:1
-    SHlwZSBDYXZlIC0gTlBDOjE=: RedBoomerang:1
+    SHlwZSBDYXZlIC0gTlBDOjE=: ThreeHundredRupees:1
     SHlwZSBDYXZlIC0gVG9wOjE=: TwentyRupees:1
     SHlydWxlIENhc3RsZSAtIE1hcCBDaGVzdDox: MapH2:1
     SHlydWxlIENhc3RsZSAtIEJvb21lcmFuZyBDaGVzdDox: Boomerang:1

--- a/presets/alttpr/vanilla.yaml
+++ b/presets/alttpr/vanilla.yaml
@@ -316,7 +316,7 @@ settings:
     QmxpbmQncyBIaWRlb3V0IC0gTGVmdDox: TwentyRupees:1
     QmxpbmQncyBIaWRlb3V0IC0gUmlnaHQ6MQ==: TwentyRupees:1
     QmxpbmQncyBIaWRlb3V0IC0gVG9wOjE=: PieceOfHeart:1
-    QnJld2VyeTox: RedBoomerang:1
+    QnJld2VyeTox: ThreeHundredRupees:1
     QnVtcGVyIENhdmU6MQ==: PieceOfHeart:1
     Qy1TaGFwZWQgSG91c2U6MQ==: ThreeHundredRupees:1
     R2Fub24ncyBUb3dlciAtIE1hcCBDaGVzdDox: MapA2:1
@@ -384,7 +384,7 @@ settings:
     SHlwZSBDYXZlIC0gQm90dG9tOjE=: TwentyRupees:1
     SHlwZSBDYXZlIC0gTWlkZGxlIExlZnQ6MQ==: TwentyRupees:1
     SHlwZSBDYXZlIC0gTWlkZGxlIFJpZ2h0OjE=: TwentyRupees:1
-    SHlwZSBDYXZlIC0gTlBDOjE=: ThreeHundredRupees:1
+    SHlwZSBDYXZlIC0gTlBDOjE=: RedBoomerang:1
     SHlwZSBDYXZlIC0gVG9wOjE=: TwentyRupees:1
     SHlydWxlIENhc3RsZSAtIE1hcCBDaGVzdDox: MapH2:1
     SHlydWxlIENhc3RsZSAtIEJvb21lcmFuZyBDaGVzdDox: Boomerang:1


### PR DESCRIPTION
Switches the locations of Hype Cave - NPC: ThreeHundredRupees with Brewery: RedBoomerang. This allows one to replicate the Vanilla any% NMG run perfectly as it requires the rupee pickup in in the Brewery, and hype cave is never visited, and at the same time keeps the red boomerang in the dark world sphere for normal vanilla players.