### PR TITLE
Update bot for recent changes to Final Fantasy Randomizer (FF1R).

### DIFF
--- a/alttprbot/alttprgen/randomizer/ffr.py
+++ b/alttprbot/alttprgen/randomizer/ffr.py
@@ -1,6 +1,11 @@
 import random
+import urllib.parse
 
-
-def roll_ffr(flags):
+def roll_ffr(url):
     seed = ('%008x' % random.randrange(16**8)).upper()
-    return seed, f"https://finalfantasyrandomizer.com/Randomize?s={seed}&f={flags}"
+    up = urllib.parse.urlparse(url)
+    qs = urllib.parse.parse_qs(up.query)
+    qs['s'] = seed
+    newurl = urllib.parse.urlunparse((up.scheme, up.netloc, up.path, up.params,
+                                      urllib.parse.urlencode(qs, doseq=True), up.fragment))
+    return seed, newurl

--- a/alttprbot_racetime/handlers/ff1r.py
+++ b/alttprbot_racetime/handlers/ff1r.py
@@ -4,25 +4,19 @@ from .core import SahasrahBotCoreHandler
 
 
 class GameHandler(SahasrahBotCoreHandler):
-    async def ex_flags(self, args, message):
+    async def ex_ff1url(self, args, message):
         try:
-            flags = args[0]
+            url = args[0]
         except IndexError:
             await self.send_message(
-                'You must specify a set of flags!'
+                'You must specify a FF1R URL with the flags!'
             )
             return
 
-        await self.roll_game(flags, message)
-
-    async def ex_sglpods(self, args, message):
-        await self.roll_game("yGcifaseK8fJxIkkAzUzYAzx32UoP5toiyJrTE864J9FEyMsXe5XhM5T94nANOh1T6wJN7BZU4p3r3WORe9o7vyXSpZD", message)
-
-    async def ex_sglbrackets(self, args, message):
-        await self.roll_game("yGq4dTUZierDQgQt0W-opZBxIHu3Djls2qM3uv02Y6KFCBgdRRG1fVdgyOD!kw3MO9U-Ez9vU4p3r3WORe9o7vyXSpZD", message)
+        await self.roll_game(url, message)
 
     async def ex_help(self, args, message):
-        await self.send_message("Available commands:\n\"!flags <flags>\" to generate seed.  Check out https://sahasrahbot.synack.live/rtgg.html#final-fantasy-randomizer-ff1r for more info.")
+        await self.send_message("Available commands:\n\"!ff1url <url>\" to generate seed.  Check out https://sahasrahbot.synack.live/rtgg.html#final-fantasy-randomizer-ff1r for more info.")
 
     async def roll_game(self, flags, message):
         if await self.is_locked(message):

--- a/docs/rtgg.md
+++ b/docs/rtgg.md
@@ -88,12 +88,12 @@ Please be aware that the flag string is not validated.
 
 ## Final Fantasy Randomizer (FF1R)
 
-### !flags
+### !ff1url
 Use this command to roll a seed number and post a link to the seed in the race info and chat.
 
-Example `!flags yGcifaseK8fJxIkkAzUzYAzx32UoP5toiyJrTE864J9FEyMsXe5XhM5T94nANOh1T6wJN7BZU4p3r3WORe9o7vyXSpZD`
+Example `!ff1url https://4-2-0.finalfantasyrandomizer.com/?s=00000000&f=AgJO1tSXqnnX-JaaScPxkw0C.ecQDS8vc3iN9TWsbcTxxkB.we6qcINzOn754c0ATcdYK..B.PZ01XbeTw-tY99fnt-lVvSvLjUusyHE85QbhZxXm2IF.YqCsdaqmyHiUAQsp90Ct.9-B
 
-Please be aware that the flag string is not validated.
+Please be aware that the URL is not validated.
 
 ## Super Metroid Randomizer (SMR)
 


### PR DESCRIPTION
FF1R recently changed how we release so that each version is deployed
as a separate site.  As a result, players need to provide a full URL
string instead of just the flags so it generates a link to the correct
version.

Because this breaks the existing ff1r !flags command, I have updated
it and renamed it to !ff1url.  The documentation is also updated.

I also removed two legacy bot commands for a past tournament that are
no longer relevant (and also don't work).