### PR TITLE
Move "crosskeys2023" preset to be the base crosskeys preset.

### DIFF
--- a/presets/alttpr/crosskeys.yaml
+++ b/presets/alttpr/crosskeys.yaml
@@ -1,6 +1,6 @@
 ---
 goal_name: "normal open keysanity + entrance shuffle"
-description: "Crossworld entrance with keysanity."
+description: "Crossworld entrance with keysanity and 100% location accessibility"
 customizer: false
 settings:
   goal: fast_ganon
@@ -23,6 +23,6 @@ settings:
   spoilers: false
   entrances: crossed
   tournament: true
-  accessibility: items
+  accessibility: locations
   dungeon_items: full
   item_placement: advanced

--- a/presets/alttpr/crosskeys_items.yaml
+++ b/presets/alttpr/crosskeys_items.yaml
@@ -1,6 +1,6 @@
 ---
 goal_name: "normal open keysanity + entrance shuffle"
-description: "Crossworld entrance with keysanity and 100% location accessibility as used for the 2023 Crosskeys Tournament."
+description: "Crossworld entrance with keysanity."
 customizer: false
 settings:
   goal: fast_ganon
@@ -23,6 +23,6 @@ settings:
   spoilers: false
   entrances: crossed
   tournament: true
-  accessibility: locations
+  accessibility: items
   dungeon_items: full
   item_placement: advanced


### PR DESCRIPTION
Move "crosskeys" to a new "crosskeys_item" preset for those who want to keep playing it.

Location accessibility has become the by-far dominant mode in racing. I've made similar changes elsewhere (eg:
https://github.com/sporchia/alttp_vt_randomizer/pull/1082). This is making everything consistent.