### PR TITLE
Z1R: add rookie rumble 2024 & 2019 tourney

### DIFF
--- a/alttprbot_racetime/handlers/z1r.py
+++ b/alttprbot_racetime/handlers/z1r.py
@@ -7,9 +7,13 @@ PRESETS = {
     'abns_swiss': 'J780EYa2ywOnCpVR1VGodM1jVyu!o5F',
     'abns_bracket': 'PPcIk!s3aupL7C41f6AhZ3mi8IwACwv',
     'abns_elite8': 'PPcIk!s3aupL9yxEvapydBFdC9X8E2A',
-    'consternation': 'ItRtYLs2xToBiCHEvfcY6eRIcxG!VfM'
+    'consternation': 'ItRtYLs2xToBiCHEvfcY6eRIcxG!VfM',
+    '2019brackets': 'ItRtYLs2xC69xBrSRTzj6AW6Ja0fcbv',
+    'rr2024': 'NuJS0dpRgVdyn25HEl8NnSW7WSfLf9v2M'
 }
-
+# A note on 2019 brackets. The flag string in Zelda Randomizer is missing
+# Recorder to New Dungeons and Shuffle Overworld Group, which were ON.
+# The flag string above turns those on, along with Race ROM.
 
 class GameHandler(SahasrahBotCoreHandler):
     async def ex_flags(self, args, message):
@@ -28,6 +32,11 @@ class GameHandler(SahasrahBotCoreHandler):
         await self.send_message(f"Z1R 2024 Tournament - Flags: ItRtYcBhrKWVT6C67oOLsUpgEaHopla Seed: {seed_number}")
         await self.set_bot_raceinfo(f"Flags: ItRtYcBhrKWVT6C67oOLsUpgEaHopla Seed: {seed_number}")
 
+    async def ex_rr2024(self, args, message):
+        seed_number = random.randint(0, 9999999999999999)
+        await self.send_message(f"Z1R Rookie Rumble 2024 - Flags: NuJS0dpRgVdyn25HEl8NnSW7WSfLf9v2M Seed: {seed_number}")
+        await self.set_bot_raceinfo(f"Flags: NuJS0dpRgVdyn25HEl8NnSW7WSfLf9v2M Seed: {seed_number}")
+
     async def ex_race(self, args, message):
         seed_number = random.randint(0, 9999999999999999)
         try:
@@ -44,7 +53,7 @@ class GameHandler(SahasrahBotCoreHandler):
 
     async def ex_help(self, args, message):
         await self.send_message(
-            "Available commands:\n\"!race <preset>\" to generate a seed.  Check out https://sahasrahbot.synack.live/rtgg.html#the-legend-of-zelda-randomizer-z1r for more info.")
+            "Available commands:\n\"!race <preset>\" or \"!flags <flagstring>\" to generate a seed.  Check out https://sahasrahbot.synack.live/rtgg.html#the-legend-of-zelda-randomizer-z1r for more info.")
 
     async def roll_game(self, flags, message):
         if await self.is_locked(message):


### PR DESCRIPTION
In response to #66 to add a rookie rumble command. After more discussion with their tournament lead, they requested that the command be `!rr2024` instead of `!rr3`, to sort of annualize the rookie tournament.