### PR TITLE
Z1R: add latest Triforce Triple Play event

### DIFF
--- a/alttprbot/alttprgen/randomizer/z1r.py
+++ b/alttprbot/alttprgen/randomizer/z1r.py
@@ -2,4 +2,4 @@ import random
 
 
 def roll_z1r(flags):
-    return random.randint(0, 9999999999999999), flags
+    return random.randint(0, 8999999999999999999), flags

--- a/alttprbot/alttprgen/randomizer/z1r.py
+++ b/alttprbot/alttprgen/randomizer/z1r.py
@@ -2,4 +2,4 @@ import random
 
 
 def roll_z1r(flags):
-    return random.randrange(0, 999999999999), flags
+    return random.randint(0, 9999999999999999), flags

--- a/alttprbot_racetime/handlers/z1r.py
+++ b/alttprbot_racetime/handlers/z1r.py
@@ -10,7 +10,14 @@ PRESETS = {
     'consternation': 'ItRtYLs2xToBiCHEvfcY6eRIcxG!VfM',
     '2019brackets': 'ItRtYLs2xC69xBrSRTzj6AW6Ja0fcbv',
     'rr2024': 'NuJS0dpRgVdyn25HEl8NnSW7WSfLf9v2M',
-    'sgl24': '9FtgnrOp3JvLxvq1Bf4xtluLDpuXvRQm2'
+    'sgl24': '9FtgnrOp3JvLxvq1Bf4xtluLDpuXvRQm2',
+    'bettypls': 'EOYppQG7Q8X5I1tNsFH8R!jOlpTT3x1tx',
+    'excavator': 'voSNknIvGu68ic41GpP4kXSjCqtAN2kNq',
+    'jesscherk': 'ItRtYM3auE3OVFlt6lBQK7khitoHMaU',
+    'magsrush': 'NNxPDPcF9p56THwiFFsHmx7x8Qod2km41',
+    'babysfirsthdn': 'Iv4gW3YU!vlmAtgUOMAM49fslZQS0ed',
+    'walkitin': '6xEziMRCF!vbiyFjZTUYKxi1V80R30fqo',
+    'swordlessplus': 'IVTU8pFHFatE6exqwxuIWuC9GkDFxAAk1'
 }
 # A note on 2019 brackets. The flag string in Zelda Randomizer is missing
 # Recorder to New Dungeons and Shuffle Overworld Group, which were ON.
@@ -29,17 +36,53 @@ class GameHandler(SahasrahBotCoreHandler):
         await self.roll_game(flags, message)
 
     async def ex_z1rtournament(self, args, message):
-        seed_number = random.randint(0, 9999999999999999)
-        await self.send_message(f"Z1R SGL 2024 Tournament - Flags: 9FtgnrOp3JvLxvq1Bf4xtluLDpuXvRQm2 Seed: {seed_number}")
-        await self.set_bot_raceinfo(f"Flags: 9FtgnrOp3JvLxvq1Bf4xtluLDpuXvRQm2 Seed: {seed_number}")
+        await self.ex_race(['sgl24'], message)
 
-    async def ex_rr2024(self, args, message):
-        seed_number = random.randint(0, 9999999999999999)
-        await self.send_message(f"Z1R Rookie Rumble 2024 - Flags: NuJS0dpRgVdyn25HEl8NnSW7WSfLf9v2M Seed: {seed_number}")
-        await self.set_bot_raceinfo(f"Flags: NuJS0dpRgVdyn25HEl8NnSW7WSfLf9v2M Seed: {seed_number}")
+    # Individual commands for these Triforce Triple Play Season 2 flags as requested.
+    async def ex_bettypls(self, args, message):
+        await self.ex_race(['bettypls'], message)
+    
+    async def ex_excavator(self, args, message):
+        await self.ex_race(['excavator'], message)
 
+    async def ex_jesscherk(self, args, message):
+        await self.ex_race(['jesscherk'], message)
+
+    async def ex_magsrush(self, args, message):
+        await self.ex_race(['magsrush'], message)
+
+    async def ex_babysfirsthdn(self, args, message):
+        await self.ex_race(['babysfirsthdn'], message)
+
+    async def ex_walkitin(self, args, message):
+        await self.ex_race(['walkitin'], message)
+
+    async def ex_swordlessplus(self, args, message):
+        await self.ex_race(['swordlessplus'], message)
+
+    async def ex_ttp2(self, args, message):
+        # Choose a Triforce Triple Play Season 2 flag string at random.
+        flag_choice = random.randint(1, 7)
+        
+        if flag_choice == 1:
+            await self.ex_race(['bettypls'], message)
+        elif flag_choice == 2:
+            await self.ex_race(['excavator'], message)
+        elif flag_choice == 3:
+            await self.ex_race(['jesscherk'], message)
+        elif flag_choice == 4:
+            await self.ex_race(['magsrush'], message)
+        elif flag_choice == 5:
+            await self.ex_race(['babysfirsthdn'], message)
+        elif flag_choice == 6:
+            await self.ex_race(['walkitin'], message)
+        else:
+            await self.ex_race(['swordlessplus'], message)
+    
     async def ex_race(self, args, message):
-        seed_number = random.randint(0, 9999999999999999)
+        if await self.is_locked(message):
+            return
+        
         try:
             preset = args[0]
             flags = PRESETS[preset]
@@ -48,9 +91,14 @@ class GameHandler(SahasrahBotCoreHandler):
             return
         except IndexError:
             await self.send_message("No preset specified.")
+            return
 
+        seed_number, flags = roll_z1r(flags)
+        
         await self.send_message(f"{preset} - Flags: {flags} Seed: {seed_number}")
         await self.set_bot_raceinfo(f"Flags: {flags} Seed: {seed_number}")
+        await self.send_message("Seed rolling complete.  See race info for details.")
+        self.seed_rolled = True
 
     async def ex_help(self, args, message):
         await self.send_message(

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -228,3 +228,21 @@ title:  Presets
 | [quick](https://github.com/tcprescott/sahasrahbot/blob/master/presets/smz3/quick.yaml) |Normal logic, ganon and mother brain open immediately, sword at uncle and morph is vanilla.|   |
 | [random](https://github.com/tcprescott/sahasrahbot/blob/master/presets/smz3/random.yaml) |Normal logic, randomized GT, Ganon, and Tourian requirements.|   |
 
+## Z1R
+
+| Preset | Description | |
+|---|---|---|
+| 2019brackets |Flags for week 5 and brackets of the 2019 tourney.  GDQ Lite with dungeon shuffle, shapes dungeons, and enemy HP shuffle.|   |
+| abns_swiss |Flags for the 2022 Z1R Summer Tournament.  Swordless, red candle guaranteed in white sword cave. Start with 3 triforces.|   |
+| abns_bracket |Flags for the bracket of the 2022 Z1R Swordless Summer Tournament.  Forced overworld block, +/- 4 HP shuffle for most enemies, and no guaranteed red candle.|   |
+| abns_elite8 |Flags for the elite 8 phase of the 2022 Z1R Swordless Summer Tournament.  Mixed-quest overworld, full start shuffle, +/- 4 HP shuffle, and 2nd Quest monsters.  Red bubbles cause slow speed.|   |
+| babysfirsthdn |For Triforce Triple Play - Season 2.  Mixed Quest - 2nd Overworld with dungeon heart shuffle, hidden dungeon numbers, and permanent sword beams.  Start with the book and boomerang.|   |
+| bettypls |For Triforce Triple Play - Season 2.  Mixed Quest - 1st Overworld with dungeon heart shuffle, 2nd Quest monsters, extra bosses and permanent sword beams. Important items are allowed in Level 9. Sword heart requirements are vanilla, and the white sword is in a cave.|   |
+| consternation |1st Quest overworld, Shapes dungeons, mixed hints, +/- 2 HP shuffle, and dungeon heart shuffle.|   |
+| excavator |For Triforce Triple Play - Season 2.  Mixed Quest - 1st Overworld, random hints, with book to understand old men.  OW blocks of the wood sword are allowed, and no extra candles, but you may get a starting red candle.  Dungeon heart shuffle, remove most open stairs.|   |
+| jesscherk |For Triforce Triple Play - Season 2.  Some 2nd Quest elements, but no walk-through walls.  You start with the recorder and 3 triforces for travel to vanilla dungeons.  Dungeon heart shuffle, and important items can be in Level 9.|   |
+| magsrush |For Triforce Triple Play - Season 2.  The Armos have your red candle with OW wood sword blocks allowed.  The magical sword can be picked up at 10 hearts, but white sword item requires 6.  Dungeon heart shuffle, and important items can be in Level 9.|   |
+| rr2024 |Flags for the 2024 Rookie Rumble.  First quest overworld, shapes dungeons, and start with a sword and bombs.  No heart shuffle.  White sword spot is guaranteed to be the recorder at 4 hearts, and magical sword is guaranteed at 10 hearts.|   |
+| sgl24 |Flags for the 2024 SGLive Tournament.  Second quest overworld, shapes dungeons, and no heart shuffle.  13 heart magical sword, and most open stair cases removed!|   |
+| swordlessplus |For Triforce Triple Play - Season 2.  House rule: not allowed to pick up the wood sword until 1-hour mark.  Possible 2nd Quest monsters.  Dungeon heart shuffle, and important items can be in Level 9. Magical sword is available at 11 hearts.|   |
+| walkitin |For Triforce Triple Play - Season 2.  Full start shuffle, blank hints, vanilla HP. Book has no extra function.|   |

--- a/docs/rtgg.md
+++ b/docs/rtgg.md
@@ -77,6 +77,15 @@ Example `!flags VlWlIEwJ1MsKkaOCWhlit2veXNSffs`
 
 Please be aware that the flag string is not validated.
 
+### !race
+Use this command in the RaceTime.gg race room.
+
+This allows you to generate a game using a pre-defined combination of settings.
+
+Example: `!race consternation`
+
+Here is a [list of currently supported presets](presets.md).
+
 ## Zelda 2 Randomizer (Z2R)
 
 ### !flags


### PR DESCRIPTION
The Z1R community now has a seasonal "Triforce Triple Play" event. Purpose is to add commands for flags that were created for the event to run in early 2025, including one to pick a preset at random, and document what is available for Z1R as we've added more presets.