### PR TITLE
Add profile management: display name, linked accounts, RaceTime unlink

### DIFF
--- a/alttprbot/presentation/web/blueprints/__init__.py
+++ b/alttprbot/presentation/web/blueprints/__init__.py
@@ -1,5 +1,6 @@
 from .asynctournament import asynctournament_blueprint
 from .presets import presets_blueprint
+from .profile import profile_blueprint
 from .racetime import racetime_blueprint
 from .ranked_choice import ranked_choice_blueprint
 from .tournament import tournament_blueprint

--- a/alttprbot/presentation/web/blueprints/profile.py
+++ b/alttprbot/presentation/web/blueprints/profile.py
@@ -1,12 +1,8 @@
-import logging
-
 from quart import Blueprint, jsonify, request
 
 from alttprbot.services import UserService
 from alttprbot.presentation.web.oauth_client import requires_authorization
 from alttprbot.presentation.web.web import discord
-
-logger = logging.getLogger(__name__)
 
 profile_blueprint = Blueprint('profile', __name__)
 
@@ -16,17 +12,14 @@ profile_blueprint = Blueprint('profile', __name__)
 async def update_display_name():
     user = await discord.fetch_user()
     payload = await request.get_json(force=True) or {}
-    display_name = payload.get('display_name') or ''
-
-    service = UserService()
-    record = await service.get_or_create_by_discord_id(int(user.id))
+    display_name = payload.get('display_name', '')
 
     try:
-        await service.update_display_name(record, display_name)
+        new_name = await UserService().set_own_display_name(int(user.id), display_name)
     except ValueError as exc:
         return jsonify(error=str(exc)), 400
 
-    return jsonify(success=True, display_name=record.display_name)
+    return jsonify(success=True, display_name=new_name)
 
 
 @profile_blueprint.route('/api/me/racetime/unlink', methods=['POST'])

--- a/alttprbot/presentation/web/blueprints/profile.py
+++ b/alttprbot/presentation/web/blueprints/profile.py
@@ -1,0 +1,42 @@
+import logging
+
+from quart import Blueprint, jsonify, request
+
+from alttprbot.services import UserService
+from alttprbot.presentation.web.oauth_client import requires_authorization
+from alttprbot.presentation.web.web import discord
+
+logger = logging.getLogger(__name__)
+
+profile_blueprint = Blueprint('profile', __name__)
+
+
+@profile_blueprint.route('/api/me/display-name', methods=['POST'])
+@requires_authorization
+async def update_display_name():
+    user = await discord.fetch_user()
+    payload = await request.get_json(force=True) or {}
+    display_name = payload.get('display_name') or ''
+
+    service = UserService()
+    record = await service.get_or_create_by_discord_id(int(user.id))
+
+    try:
+        await service.update_display_name(record, display_name)
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 400
+
+    return jsonify(success=True, display_name=record.display_name)
+
+
+@profile_blueprint.route('/api/me/racetime/unlink', methods=['POST'])
+@requires_authorization
+async def unlink_racetime():
+    user = await discord.fetch_user()
+
+    try:
+        await UserService().unlink_racetime_account(int(user.id))
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 400
+
+    return jsonify(success=True)

--- a/alttprbot/presentation/web/spa/src/hooks/useMe.ts
+++ b/alttprbot/presentation/web/spa/src/hooks/useMe.ts
@@ -8,10 +8,18 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 // throws on any other non-OK response.
 // ---------------------------------------------------------------------------
 
+export interface LinkedAccounts {
+  discord: { linked: true; username: string };
+  racetime: { linked: boolean; id: string | null; url: string | null };
+  twitch: { linked: boolean; name: string | null };
+}
+
 export interface MeData {
   id: string;
   name: string;
   avatar_url: string;
+  display_name: string | null;
+  linked_accounts: LinkedAccounts;
 }
 
 async function fetchMe(): Promise<MeData | null> {

--- a/alttprbot/presentation/web/spa/src/hooks/useMe.ts
+++ b/alttprbot/presentation/web/spa/src/hooks/useMe.ts
@@ -30,6 +30,8 @@ async function fetchMe(): Promise<MeData | null> {
   return body.data;
 }
 
+export const meQueryKey = ['me'] as const;
+
 export function useMe(): UseQueryResult<MeData | null> {
-  return useQuery({ queryKey: ['me'], queryFn: fetchMe });
+  return useQuery({ queryKey: meQueryKey, queryFn: fetchMe });
 }

--- a/alttprbot/presentation/web/spa/src/pages/ProfilePage.tsx
+++ b/alttprbot/presentation/web/spa/src/pages/ProfilePage.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { Badge } from '../components/ui/Badge';
 import { useMe, type MeData } from '../hooks/useMe';
 import '../styles/submit.css';
@@ -46,7 +48,150 @@ function UnauthenticatedPanel() {
   );
 }
 
-function ProfileCard({ user }: { user: MeData }) {
+function DisplayNameSection({ user, onChanged }: { user: MeData; onChanged: () => void }) {
+  const [value, setValue] = useState(user.display_name ?? '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const dirty = value.trim() !== (user.display_name ?? '');
+
+  async function handleSave() {
+    setError(null);
+    setSuccess(false);
+    setSaving(true);
+    try {
+      const r = await fetch('/api/me/display-name', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ display_name: value }),
+      });
+      const body = (await r.json().catch(() => ({}))) as { success?: boolean; display_name?: string; error?: string };
+      if (!r.ok || body.error) { setError(body.error ?? `Save failed (${r.status}).`); return; }
+      setSuccess(true);
+      onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="profile-section">
+      <p className="profile-section-title">Display Name</p>
+      <p className="profile-section-desc">
+        Shown across tournaments and leaderboards instead of your Discord name.
+      </p>
+      {error && (
+        <div className="alert alert-error" role="alert">
+          <span className="alert-icon">⚠</span>
+          <p>{error}</p>
+        </div>
+      )}
+      {success && (
+        <div className="alert alert-success" role="status">
+          <span className="alert-icon">✓</span>
+          <p>Display name updated.</p>
+        </div>
+      )}
+      <div className="field" style={{ display: 'flex', gap: '.6rem', alignItems: 'center', flexWrap: 'wrap' }}>
+        <input
+          className="control"
+          value={value}
+          onChange={(e) => { setValue(e.target.value); setSuccess(false); }}
+          maxLength={32}
+          placeholder="Not set"
+          disabled={saving}
+          aria-label="Display name"
+        />
+        <button
+          className="btn btn-ghost btn-sm"
+          onClick={() => void handleSave()}
+          disabled={saving || !dirty || value.trim().length === 0}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function LinkedAccountsSection({ user, onChanged }: { user: MeData; onChanged: () => void }) {
+  const [unlinking, setUnlinking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { discord, racetime, twitch } = user.linked_accounts;
+
+  async function handleUnlinkRacetime() {
+    setError(null);
+    setUnlinking(true);
+    try {
+      const r = await fetch('/api/me/racetime/unlink', { method: 'POST' });
+      const body = (await r.json().catch(() => ({}))) as { success?: boolean; error?: string };
+      if (!r.ok || body.error) { setError(body.error ?? `Unlink failed (${r.status}).`); return; }
+      onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred.');
+    } finally {
+      setUnlinking(false);
+    }
+  }
+
+  return (
+    <div className="profile-section">
+      <p className="profile-section-title">Linked Accounts</p>
+      {error && (
+        <div className="alert alert-error" role="alert">
+          <span className="alert-icon">⚠</span>
+          <p>{error}</p>
+        </div>
+      )}
+
+      <div className="profile-linked-row">
+        <div className="profile-linked-label">
+          <Badge tone="teal" dot>Discord</Badge>
+          <span className="profile-linked-value">{discord.username}</span>
+        </div>
+      </div>
+
+      <div className="profile-linked-row">
+        <div className="profile-linked-label">
+          <Badge tone={racetime.linked ? 'teal' : 'default'} dot={racetime.linked}>RaceTime.gg</Badge>
+          {racetime.linked ? (
+            <a className="profile-linked-value" href={racetime.url ?? undefined} target="_blank" rel="noreferrer">
+              {racetime.id}
+            </a>
+          ) : (
+            <span className="profile-linked-value muted">Not linked</span>
+          )}
+        </div>
+        {racetime.linked ? (
+          <button className="btn btn-ghost btn-sm" onClick={() => void handleUnlinkRacetime()} disabled={unlinking}>
+            {unlinking ? 'Unlinking…' : 'Unlink'}
+          </button>
+        ) : (
+          <a className="btn btn-ghost btn-sm" href="/racetime/verification/initiate">
+            Link account <span className="arr">→</span>
+          </a>
+        )}
+      </div>
+
+      <div className="profile-linked-row">
+        <div className="profile-linked-label">
+          <Badge tone={twitch.linked ? 'teal' : 'default'} dot={twitch.linked}>Twitch</Badge>
+          {twitch.linked ? (
+            <span className="profile-linked-value">{twitch.name}</span>
+          ) : (
+            <span className="profile-linked-value muted">Not linked</span>
+          )}
+        </div>
+        <span className="profile-linked-hint">Synced automatically from tournament registration</span>
+      </div>
+    </div>
+  );
+}
+
+function ProfileCard({ user, onChanged }: { user: MeData; onChanged: () => void }) {
   return (
     <div className="panel" style={{ maxWidth: 680 }}>
       <div className="panel-head">
@@ -70,16 +215,9 @@ function ProfileCard({ user }: { user: MeData }) {
           </div>
         </div>
 
-        {/* RaceTime Verification */}
-        <div className="profile-section">
-          <p className="profile-section-title">RaceTime Verification</p>
-          <p className="profile-section-desc">
-            Link your RaceTime.gg account to participate in bot-managed races.
-          </p>
-          <a className="btn btn-ghost btn-sm" href="/racetime/verification/initiate">
-            Verify RaceTime Account <span className="arr">→</span>
-          </a>
-        </div>
+        <DisplayNameSection user={user} onChanged={onChanged} />
+
+        <LinkedAccountsSection user={user} onChanged={onChanged} />
 
         {/* Manage Presets */}
         <div className="profile-section">
@@ -114,6 +252,8 @@ function ProfileCard({ user }: { user: MeData }) {
 
 export function ProfilePage() {
   const { data: user, isLoading, error } = useMe();
+  const queryClient = useQueryClient();
+  const handleChanged = () => { void queryClient.invalidateQueries({ queryKey: ['me'] }); };
 
   const pageHead = (
     <section className="pagehead">
@@ -163,7 +303,7 @@ export function ProfilePage() {
             </div>
           )}
 
-          {user && <ProfileCard user={user} />}
+          {user && <ProfileCard user={user} onChanged={handleChanged} />}
 
         </div>
       </section>

--- a/alttprbot/presentation/web/spa/src/pages/ProfilePage.tsx
+++ b/alttprbot/presentation/web/spa/src/pages/ProfilePage.tsx
@@ -2,9 +2,25 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { Badge } from '../components/ui/Badge';
-import { useMe, type MeData } from '../hooks/useMe';
+import { useMe, meQueryKey, type MeData } from '../hooks/useMe';
 import '../styles/submit.css';
 import '../styles/profile.css';
+
+// ---------------------------------------------------------------------------
+// Shared POST helper for the mutations below — keeps fetch/parse/error
+// handling in one place instead of duplicated per section.
+// ---------------------------------------------------------------------------
+
+async function postJson<T extends { error?: string } = { error?: string }>(url: string, body?: unknown): Promise<T> {
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: body !== undefined ? { 'Content-Type': 'application/json' } : undefined,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const data = (await r.json().catch(() => ({}))) as T;
+  if (!r.ok || data.error) throw new Error(data.error ?? `Request failed (${r.status}).`);
+  return data;
+}
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -61,13 +77,10 @@ function DisplayNameSection({ user, onChanged }: { user: MeData; onChanged: () =
     setSuccess(false);
     setSaving(true);
     try {
-      const r = await fetch('/api/me/display-name', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ display_name: value }),
-      });
-      const body = (await r.json().catch(() => ({}))) as { success?: boolean; display_name?: string; error?: string };
-      if (!r.ok || body.error) { setError(body.error ?? `Save failed (${r.status}).`); return; }
+      const body = await postJson<{ display_name?: string; error?: string }>('/api/me/display-name', { display_name: value });
+      // Resync to the server's (trimmed/validated) value rather than leaving
+      // the raw input text, so the field can't drift from what was persisted.
+      if (body.display_name !== undefined) setValue(body.display_name);
       setSuccess(true);
       onChanged();
     } catch (err) {
@@ -123,12 +136,16 @@ function LinkedAccountsSection({ user, onChanged }: { user: MeData; onChanged: (
   const { discord, racetime, twitch } = user.linked_accounts;
 
   async function handleUnlinkRacetime() {
+    const confirmed = window.confirm(
+      'Unlink your RaceTime.gg account? This may affect verified-racer roles, tournament ' +
+      'eligibility, or race entries that depend on it. You can link it again at any time.'
+    );
+    if (!confirmed) return;
+
     setError(null);
     setUnlinking(true);
     try {
-      const r = await fetch('/api/me/racetime/unlink', { method: 'POST' });
-      const body = (await r.json().catch(() => ({}))) as { success?: boolean; error?: string };
-      if (!r.ok || body.error) { setError(body.error ?? `Unlink failed (${r.status}).`); return; }
+      await postJson('/api/me/racetime/unlink');
       onChanged();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unexpected error occurred.');
@@ -253,7 +270,7 @@ function ProfileCard({ user, onChanged }: { user: MeData; onChanged: () => void 
 export function ProfilePage() {
   const { data: user, isLoading, error } = useMe();
   const queryClient = useQueryClient();
-  const handleChanged = () => { void queryClient.invalidateQueries({ queryKey: ['me'] }); };
+  const handleChanged = () => { void queryClient.invalidateQueries({ queryKey: meQueryKey }); };
 
   const pageHead = (
     <section className="pagehead">

--- a/alttprbot/presentation/web/spa/src/styles/profile.css
+++ b/alttprbot/presentation/web/spa/src/styles/profile.css
@@ -93,6 +93,39 @@
   color: var(--crimson);
 }
 
+/* linked-account rows */
+.profile-linked-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .8rem;
+  flex-wrap: wrap;
+  padding: .55rem 0;
+}
+
+.profile-linked-label {
+  display: flex;
+  align-items: center;
+  gap: .7rem;
+  flex-wrap: wrap;
+}
+
+.profile-linked-value {
+  font-family: 'Space Mono', monospace;
+  font-size: .85rem;
+  color: var(--ink-soft);
+}
+
+.profile-linked-value.muted {
+  color: var(--ink-faint);
+  font-style: italic;
+}
+
+.profile-linked-hint {
+  font-size: .78rem;
+  color: var(--ink-faint);
+}
+
 /* unauthenticated prompt */
 .profile-auth-prompt {
   display: flex;

--- a/alttprbot/presentation/web/web.py
+++ b/alttprbot/presentation/web/web.py
@@ -187,24 +187,17 @@ async def api_me():
     name = user._data.get('global_name') or user._data.get('username', '')
     username = user._data.get('username', '')
 
-    profile = await UserService().get_by_discord_id(int(user_id))
+    summary = await UserService().get_account_summary(int(user_id))
 
     return jsonify(data=dict(
         id=user_id,
         name=name,
         avatar_url=avatar_url,
-        display_name=profile.display_name if profile else None,
+        display_name=summary["display_name"],
         linked_accounts=dict(
             discord=dict(linked=True, username=username),
-            racetime=dict(
-                linked=bool(profile and profile.rtgg_id),
-                id=profile.rtgg_id if profile else None,
-                url=profile.racetime_profile if profile else None,
-            ),
-            twitch=dict(
-                linked=bool(profile and profile.twitch_name),
-                name=profile.twitch_name if profile else None,
-            ),
+            racetime=summary["racetime"],
+            twitch=summary["twitch"],
         ),
     ))
 

--- a/alttprbot/presentation/web/web.py
+++ b/alttprbot/presentation/web/web.py
@@ -8,7 +8,7 @@ from quart import (Quart, abort, jsonify, redirect, request,
 from werkzeug.utils import safe_join
 
 import config
-from alttprbot.services import NickVerificationService, PresetService
+from alttprbot.services import NickVerificationService, PresetService, UserService
 from alttprbot.presentation.discord.bot import discordbot
 
 logger = logging.getLogger(__name__)
@@ -50,6 +50,7 @@ logger.info("OAuth: Using Authlib implementation")
 import alttprbot.presentation.web.blueprints as blueprints  # nopep8
 
 sahasrahbotapi.register_blueprint(blueprints.presets_blueprint)
+sahasrahbotapi.register_blueprint(blueprints.profile_blueprint)
 sahasrahbotapi.register_blueprint(blueprints.racetime_blueprint)
 sahasrahbotapi.register_blueprint(blueprints.ranked_choice_blueprint)
 sahasrahbotapi.register_blueprint(blueprints.tournament_blueprint)
@@ -184,7 +185,28 @@ async def api_me():
         avatar_url = f"https://cdn.discordapp.com/embed/avatars/{discriminator % 5}.png"
 
     name = user._data.get('global_name') or user._data.get('username', '')
-    return jsonify(data=dict(id=user_id, name=name, avatar_url=avatar_url))
+    username = user._data.get('username', '')
+
+    profile = await UserService().get_by_discord_id(int(user_id))
+
+    return jsonify(data=dict(
+        id=user_id,
+        name=name,
+        avatar_url=avatar_url,
+        display_name=profile.display_name if profile else None,
+        linked_accounts=dict(
+            discord=dict(linked=True, username=username),
+            racetime=dict(
+                linked=bool(profile and profile.rtgg_id),
+                id=profile.rtgg_id if profile else None,
+                url=profile.racetime_profile if profile else None,
+            ),
+            twitch=dict(
+                linked=bool(profile and profile.twitch_name),
+                name=profile.twitch_name if profile else None,
+            ),
+        ),
+    ))
 
 
 @sahasrahbotapi.route('/spa-assets/<path:filename>', methods=['GET'])

--- a/alttprbot/repositories/user_repository.py
+++ b/alttprbot/repositories/user_repository.py
@@ -54,6 +54,12 @@ class UserRepository:
         await user.save()
 
     @staticmethod
+    async def clear_racetime_link(user: models.Users) -> None:
+        user.rtgg_id = None
+        user.rtgg_access_token = None
+        await user.save()
+
+    @staticmethod
     async def merge(user_to_keep: models.Users, victim: models.Users) -> models.Users:
         """Fold ``victim`` into ``user_to_keep``: adopt ids, reassign owned rows, delete victim.
 

--- a/alttprbot/services/user_service.py
+++ b/alttprbot/services/user_service.py
@@ -1,11 +1,14 @@
 """User account service: lookups, RaceTime account linking and merges."""
 
+import logging
 from typing import Optional
 
 from tortoise.exceptions import IntegrityError
 
 from alttprbot import models
 from alttprbot.repositories import UserRepository
+
+logger = logging.getLogger(__name__)
 
 
 class UserService:
@@ -24,15 +27,49 @@ class UserService:
     async def list_users_without_display_name(self) -> "list[models.Users]":
         return await self.repository.list_without_display_name()
 
-    async def update_display_name(self, user: models.Users, display_name: str) -> None:
+    @staticmethod
+    def _validate_display_name(display_name) -> str:
+        if not isinstance(display_name, str):
+            raise ValueError("Display name must be text.")
         display_name = display_name.strip()
         if not 1 <= len(display_name) <= 32:
             raise ValueError("Display name must be between 1 and 32 characters.")
+        return display_name
+
+    async def update_display_name(self, user: models.Users, display_name: str) -> None:
+        display_name = self._validate_display_name(display_name)
 
         try:
             await self.repository.set_display_name(user, display_name)
         except IntegrityError as exc:
             raise ValueError("That display name is already taken.") from exc
+
+    async def set_own_display_name(self, discord_user_id: int, display_name: str) -> str:
+        """Validate and persist a user-chosen display name, creating the user row if needed.
+
+        Validates before touching the database so an invalid name from a brand-new
+        visitor doesn't leave behind a junk ``Users`` row.
+        """
+        display_name = self._validate_display_name(display_name)
+        user = await self.get_or_create_by_discord_id(discord_user_id)
+        await self.update_display_name(user, display_name)
+        return user.display_name
+
+    async def get_account_summary(self, discord_user_id: int) -> dict:
+        """Linked-account state for the profile page, keyed by provider."""
+        user = await self.repository.get_by_discord_id(discord_user_id)
+        return {
+            "display_name": user.display_name if user else None,
+            "racetime": {
+                "linked": bool(user and user.rtgg_id),
+                "id": user.rtgg_id if user else None,
+                "url": user.racetime_profile if user else None,
+            },
+            "twitch": {
+                "linked": bool(user and user.twitch_name),
+                "name": user.twitch_name if user else None,
+            },
+        }
 
     async def get_or_create_by_discord_id(
         self, discord_user_id: int, *, display_name: Optional[str] = None
@@ -51,24 +88,35 @@ class UserService:
         - both a rtgg-keyed and a discord-keyed user exist and differ -> merge them;
         - no rtgg-keyed user -> upsert keyed on the discord id;
         - otherwise -> upsert keyed on the rtgg id.
+
+        The Discord username is only a *fallback* display name: it's applied when
+        the user doesn't already have one, but never overwrites a name the user
+        chose for themselves via the profile page.
         """
         rtgg_user = await self.repository.get_by_rtgg_id(rtgg_id)
         discord_user = await self.repository.get_by_discord_id(discord_user_id)
 
         if rtgg_user != discord_user and rtgg_user is not None and discord_user is not None:
             kept_user = await self.repository.merge(rtgg_user, discord_user)
-            kept_user.display_name = display_name
-            await kept_user.save()
+            if not kept_user.display_name:
+                kept_user.display_name = display_name
+                try:
+                    await kept_user.save()
+                except IntegrityError:
+                    logger.warning(
+                        "Skipped fallback display name %r after RaceTime merge: name already taken.",
+                        display_name,
+                    )
         elif rtgg_user is None:
-            await self.repository.upsert_by_discord_id(
-                discord_user_id,
-                {"rtgg_id": rtgg_id, "rtgg_access_token": access_token, "display_name": display_name},
-            )
+            defaults = {"rtgg_id": rtgg_id, "rtgg_access_token": access_token}
+            if discord_user is None or not discord_user.display_name:
+                defaults["display_name"] = display_name
+            await self.repository.upsert_by_discord_id(discord_user_id, defaults)
         else:
-            await self.repository.upsert_by_rtgg_id(
-                rtgg_id,
-                {"discord_user_id": discord_user_id, "rtgg_access_token": access_token, "display_name": display_name},
-            )
+            defaults = {"discord_user_id": discord_user_id, "rtgg_access_token": access_token}
+            if not rtgg_user.display_name:
+                defaults["display_name"] = display_name
+            await self.repository.upsert_by_rtgg_id(rtgg_id, defaults)
 
     async def unlink_racetime_account(self, discord_user_id: int) -> None:
         """Clear a user's linked RaceTime.gg identity (local link only, no upstream revoke)."""

--- a/alttprbot/services/user_service.py
+++ b/alttprbot/services/user_service.py
@@ -2,6 +2,8 @@
 
 from typing import Optional
 
+from tortoise.exceptions import IntegrityError
+
 from alttprbot import models
 from alttprbot.repositories import UserRepository
 
@@ -23,7 +25,14 @@ class UserService:
         return await self.repository.list_without_display_name()
 
     async def update_display_name(self, user: models.Users, display_name: str) -> None:
-        await self.repository.set_display_name(user, display_name)
+        display_name = display_name.strip()
+        if not 1 <= len(display_name) <= 32:
+            raise ValueError("Display name must be between 1 and 32 characters.")
+
+        try:
+            await self.repository.set_display_name(user, display_name)
+        except IntegrityError as exc:
+            raise ValueError("That display name is already taken.") from exc
 
     async def get_or_create_by_discord_id(
         self, discord_user_id: int, *, display_name: Optional[str] = None
@@ -60,3 +69,11 @@ class UserService:
                 rtgg_id,
                 {"discord_user_id": discord_user_id, "rtgg_access_token": access_token, "display_name": display_name},
             )
+
+    async def unlink_racetime_account(self, discord_user_id: int) -> None:
+        """Clear a user's linked RaceTime.gg identity (local link only, no upstream revoke)."""
+        user = await self.repository.get_by_discord_id(discord_user_id)
+        if user is None or user.rtgg_id is None:
+            raise ValueError("No RaceTime.gg account is linked.")
+
+        await self.repository.clear_racetime_link(user)

--- a/tests/integration/web/test_profile_blueprint.py
+++ b/tests/integration/web/test_profile_blueprint.py
@@ -1,0 +1,111 @@
+"""Route tests for the profile endpoints: GET /api/me, display-name update,
+and RaceTime unlink.
+
+See alttprbot/presentation/web/web.py (api_me) and
+alttprbot/presentation/web/blueprints/profile.py.
+"""
+
+from unittest.mock import AsyncMock
+
+from alttprbot.presentation.web import web as web_module
+from alttprbot.presentation.web.oauth_client import DiscordUser
+from alttprbot.services import UserService
+
+DISCORD_USER = DiscordUser({
+    "id": "123",
+    "username": "tester",
+    "global_name": "Tester",
+    "discriminator": "0",
+    "avatar": None,
+})
+
+
+async def sign_in(client):
+    async with client.session_transaction() as session:
+        session["discord_oauth_token"] = {"access_token": "tok", "token_type": "Bearer"}
+
+
+async def test_api_me_unauthenticated_returns_401(client):
+    resp = await client.get("/api/me")
+    assert resp.status_code == 401
+    assert (await resp.get_json())["error"] == "unauthenticated"
+
+
+async def test_api_me_includes_linked_account_state(client, monkeypatch):
+    await sign_in(client)
+    monkeypatch.setattr(web_module.discord, "fetch_user", AsyncMock(return_value=DISCORD_USER))
+    profile = AsyncMock(return_value=None)
+    monkeypatch.setattr(UserService, "get_by_discord_id", profile)
+
+    resp = await client.get("/api/me")
+    assert resp.status_code == 200
+    data = (await resp.get_json())["data"]
+    assert data["display_name"] is None
+    assert data["linked_accounts"]["discord"] == {"linked": True, "username": "tester"}
+    assert data["linked_accounts"]["racetime"] == {"linked": False, "id": None, "url": None}
+    assert data["linked_accounts"]["twitch"] == {"linked": False, "name": None}
+
+
+async def test_display_name_update_requires_auth(client):
+    # @requires_authorization redirects to /login/ rather than 401ing, same as
+    # the other session-authenticated web routes (racetime.py, presets.py).
+    resp = await client.post("/api/me/display-name", json={"display_name": "Alice"})
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/login/"
+
+
+async def test_display_name_update_rejects_invalid_name(client, monkeypatch):
+    await sign_in(client)
+    monkeypatch.setattr(web_module.discord, "fetch_user", AsyncMock(return_value=DISCORD_USER))
+    monkeypatch.setattr(UserService, "get_or_create_by_discord_id", AsyncMock(return_value=AsyncMock()))
+
+    resp = await client.post("/api/me/display-name", json={"display_name": "   "})
+    assert resp.status_code == 400
+    assert "error" in (await resp.get_json())
+
+
+async def test_display_name_update_succeeds(client, monkeypatch):
+    await sign_in(client)
+    monkeypatch.setattr(web_module.discord, "fetch_user", AsyncMock(return_value=DISCORD_USER))
+
+    record = AsyncMock()
+    record.display_name = "Alice"
+    monkeypatch.setattr(UserService, "get_or_create_by_discord_id", AsyncMock(return_value=record))
+    update_mock = AsyncMock()
+    monkeypatch.setattr(UserService, "update_display_name", update_mock)
+
+    resp = await client.post("/api/me/display-name", json={"display_name": "Alice"})
+    assert resp.status_code == 200
+    body = await resp.get_json()
+    assert body["success"] is True
+    update_mock.assert_awaited_once_with(record, "Alice")
+
+
+async def test_racetime_unlink_requires_auth(client):
+    resp = await client.post("/api/me/racetime/unlink")
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/login/"
+
+
+async def test_racetime_unlink_succeeds(client, monkeypatch):
+    await sign_in(client)
+    monkeypatch.setattr(web_module.discord, "fetch_user", AsyncMock(return_value=DISCORD_USER))
+    unlink_mock = AsyncMock()
+    monkeypatch.setattr(UserService, "unlink_racetime_account", unlink_mock)
+
+    resp = await client.post("/api/me/racetime/unlink")
+    assert resp.status_code == 200
+    assert (await resp.get_json())["success"] is True
+    unlink_mock.assert_awaited_once_with(123)
+
+
+async def test_racetime_unlink_returns_400_when_not_linked(client, monkeypatch):
+    await sign_in(client)
+    monkeypatch.setattr(web_module.discord, "fetch_user", AsyncMock(return_value=DISCORD_USER))
+    monkeypatch.setattr(
+        UserService, "unlink_racetime_account", AsyncMock(side_effect=ValueError("No RaceTime.gg account is linked."))
+    )
+
+    resp = await client.post("/api/me/racetime/unlink")
+    assert resp.status_code == 400
+    assert "error" in (await resp.get_json())

--- a/tests/integration/web/test_profile_blueprint.py
+++ b/tests/integration/web/test_profile_blueprint.py
@@ -34,8 +34,12 @@ async def test_api_me_unauthenticated_returns_401(client):
 async def test_api_me_includes_linked_account_state(client, monkeypatch):
     await sign_in(client)
     monkeypatch.setattr(web_module.discord, "fetch_user", AsyncMock(return_value=DISCORD_USER))
-    profile = AsyncMock(return_value=None)
-    monkeypatch.setattr(UserService, "get_by_discord_id", profile)
+    summary = AsyncMock(return_value={
+        "display_name": None,
+        "racetime": {"linked": False, "id": None, "url": None},
+        "twitch": {"linked": False, "name": None},
+    })
+    monkeypatch.setattr(UserService, "get_account_summary", summary)
 
     resp = await client.get("/api/me")
     assert resp.status_code == 200
@@ -44,6 +48,7 @@ async def test_api_me_includes_linked_account_state(client, monkeypatch):
     assert data["linked_accounts"]["discord"] == {"linked": True, "username": "tester"}
     assert data["linked_accounts"]["racetime"] == {"linked": False, "id": None, "url": None}
     assert data["linked_accounts"]["twitch"] == {"linked": False, "name": None}
+    summary.assert_awaited_once_with(123)
 
 
 async def test_display_name_update_requires_auth(client):
@@ -55,11 +60,20 @@ async def test_display_name_update_requires_auth(client):
 
 
 async def test_display_name_update_rejects_invalid_name(client, monkeypatch):
+    # Validation happens before any repository access, so no DB-layer mocking is needed.
     await sign_in(client)
     monkeypatch.setattr(web_module.discord, "fetch_user", AsyncMock(return_value=DISCORD_USER))
-    monkeypatch.setattr(UserService, "get_or_create_by_discord_id", AsyncMock(return_value=AsyncMock()))
 
     resp = await client.post("/api/me/display-name", json={"display_name": "   "})
+    assert resp.status_code == 400
+    assert "error" in (await resp.get_json())
+
+
+async def test_display_name_update_rejects_non_string(client, monkeypatch):
+    await sign_in(client)
+    monkeypatch.setattr(web_module.discord, "fetch_user", AsyncMock(return_value=DISCORD_USER))
+
+    resp = await client.post("/api/me/display-name", json={"display_name": 123})
     assert resp.status_code == 400
     assert "error" in (await resp.get_json())
 
@@ -67,18 +81,15 @@ async def test_display_name_update_rejects_invalid_name(client, monkeypatch):
 async def test_display_name_update_succeeds(client, monkeypatch):
     await sign_in(client)
     monkeypatch.setattr(web_module.discord, "fetch_user", AsyncMock(return_value=DISCORD_USER))
-
-    record = AsyncMock()
-    record.display_name = "Alice"
-    monkeypatch.setattr(UserService, "get_or_create_by_discord_id", AsyncMock(return_value=record))
-    update_mock = AsyncMock()
-    monkeypatch.setattr(UserService, "update_display_name", update_mock)
+    set_name_mock = AsyncMock(return_value="Alice")
+    monkeypatch.setattr(UserService, "set_own_display_name", set_name_mock)
 
     resp = await client.post("/api/me/display-name", json={"display_name": "Alice"})
     assert resp.status_code == 200
     body = await resp.get_json()
     assert body["success"] is True
-    update_mock.assert_awaited_once_with(record, "Alice")
+    assert body["display_name"] == "Alice"
+    set_name_mock.assert_awaited_once_with(123, "Alice")
 
 
 async def test_racetime_unlink_requires_auth(client):

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -12,7 +12,7 @@ async def test_link_upserts_by_discord_when_no_rtgg_user():
     service = UserService()
     service.repository = AsyncMock()
     service.repository.get_by_rtgg_id.return_value = None
-    service.repository.get_by_discord_id.return_value = MagicMock()  # discord user exists
+    service.repository.get_by_discord_id.return_value = MagicMock(display_name=None)  # discord user exists, no name yet
 
     await service.link_racetime_account(
         discord_user_id=10, display_name="Alice", rtgg_id="rt1", access_token="tok"
@@ -27,7 +27,7 @@ async def test_link_upserts_by_discord_when_no_rtgg_user():
 async def test_link_upserts_by_rtgg_when_no_conflict():
     service = UserService()
     service.repository = AsyncMock()
-    same = MagicMock()
+    same = MagicMock(display_name=None)
     service.repository.get_by_rtgg_id.return_value = same
     service.repository.get_by_discord_id.return_value = same  # same row -> no merge
 
@@ -48,7 +48,7 @@ async def test_link_merges_when_two_distinct_users_exist():
     discord_user = MagicMock()
     service.repository.get_by_rtgg_id.return_value = rtgg_user
     service.repository.get_by_discord_id.return_value = discord_user
-    kept = MagicMock()
+    kept = MagicMock(display_name=None)
     kept.save = AsyncMock()
     service.repository.merge.return_value = kept
 
@@ -58,6 +58,74 @@ async def test_link_merges_when_two_distinct_users_exist():
 
     service.repository.merge.assert_awaited_once_with(rtgg_user, discord_user)
     assert kept.display_name == "Alice"
+    kept.save.assert_awaited_once()
+
+
+async def test_link_preserves_existing_display_name_on_discord_upsert():
+    service = UserService()
+    service.repository = AsyncMock()
+    service.repository.get_by_rtgg_id.return_value = None
+    service.repository.get_by_discord_id.return_value = MagicMock(display_name="Zeldex")
+
+    await service.link_racetime_account(
+        discord_user_id=10, display_name="Alice", rtgg_id="rt1", access_token="tok"
+    )
+
+    service.repository.upsert_by_discord_id.assert_awaited_once_with(
+        10, {"rtgg_id": "rt1", "rtgg_access_token": "tok"}
+    )
+
+
+async def test_link_preserves_existing_display_name_on_rtgg_upsert():
+    service = UserService()
+    service.repository = AsyncMock()
+    same = MagicMock(display_name="Zeldex")
+    service.repository.get_by_rtgg_id.return_value = same
+    service.repository.get_by_discord_id.return_value = same
+
+    await service.link_racetime_account(
+        discord_user_id=10, display_name="Alice", rtgg_id="rt1", access_token="tok"
+    )
+
+    service.repository.upsert_by_rtgg_id.assert_awaited_once_with(
+        "rt1", {"discord_user_id": 10, "rtgg_access_token": "tok"}
+    )
+
+
+async def test_link_preserves_existing_display_name_on_merge():
+    service = UserService()
+    service.repository = AsyncMock()
+    rtgg_user = MagicMock()
+    discord_user = MagicMock()
+    service.repository.get_by_rtgg_id.return_value = rtgg_user
+    service.repository.get_by_discord_id.return_value = discord_user
+    kept = MagicMock(display_name="Zeldex")
+    kept.save = AsyncMock()
+    service.repository.merge.return_value = kept
+
+    await service.link_racetime_account(
+        discord_user_id=10, display_name="Alice", rtgg_id="rt1", access_token="tok"
+    )
+
+    assert kept.display_name == "Zeldex"
+    kept.save.assert_not_awaited()
+
+
+async def test_link_swallows_integrity_error_on_merge_fallback_name():
+    service = UserService()
+    service.repository = AsyncMock()
+    rtgg_user = MagicMock()
+    discord_user = MagicMock()
+    service.repository.get_by_rtgg_id.return_value = rtgg_user
+    service.repository.get_by_discord_id.return_value = discord_user
+    kept = MagicMock(display_name=None)
+    kept.save = AsyncMock(side_effect=IntegrityError())
+    service.repository.merge.return_value = kept
+
+    await service.link_racetime_account(
+        discord_user_id=10, display_name="Alice", rtgg_id="rt1", access_token="tok"
+    )  # must not raise -- a collision on the fallback name shouldn't fail the whole link
+
     kept.save.assert_awaited_once()
 
 
@@ -92,6 +160,16 @@ async def test_unlink_racetime_account_raises_when_not_linked():
         await service.unlink_racetime_account(10)
 
     service.repository.clear_racetime_link.assert_not_awaited()
+
+
+async def test_update_display_name_rejects_non_string():
+    service = UserService()
+    service.repository = AsyncMock()
+
+    with pytest.raises(ValueError):
+        await service.update_display_name(MagicMock(), 123)
+
+    service.repository.set_display_name.assert_not_awaited()
 
 
 async def test_update_display_name_rejects_empty():
@@ -131,6 +209,62 @@ async def test_update_display_name_raises_on_duplicate():
 
     with pytest.raises(ValueError):
         await service.update_display_name(MagicMock(), "Alice")
+
+
+async def test_get_account_summary_with_no_user():
+    service = UserService()
+    service.repository = AsyncMock()
+    service.repository.get_by_discord_id.return_value = None
+
+    summary = await service.get_account_summary(10)
+
+    assert summary == {
+        "display_name": None,
+        "racetime": {"linked": False, "id": None, "url": None},
+        "twitch": {"linked": False, "name": None},
+    }
+
+
+async def test_get_account_summary_with_linked_user():
+    service = UserService()
+    service.repository = AsyncMock()
+    user = MagicMock(display_name="Zeldex", rtgg_id="rt1", twitch_name="zeldex_tv")
+    user.racetime_profile = "https://racetime.gg/user/rt1/"
+    service.repository.get_by_discord_id.return_value = user
+
+    summary = await service.get_account_summary(10)
+
+    assert summary == {
+        "display_name": "Zeldex",
+        "racetime": {"linked": True, "id": "rt1", "url": "https://racetime.gg/user/rt1/"},
+        "twitch": {"linked": True, "name": "zeldex_tv"},
+    }
+
+
+async def test_set_own_display_name_validates_before_touching_repository():
+    service = UserService()
+    service.repository = AsyncMock()
+
+    with pytest.raises(ValueError):
+        await service.set_own_display_name(10, "   ")
+
+    service.repository.get_or_create_by_discord_id.assert_not_awaited()
+
+
+async def test_set_own_display_name_creates_and_saves():
+    service = UserService()
+    service.repository = AsyncMock()
+    user = MagicMock(display_name=None)
+    service.repository.get_or_create_by_discord_id.return_value = (user, True)
+
+    async def fake_set_display_name(target, name):
+        target.display_name = name
+    service.repository.set_display_name.side_effect = fake_set_display_name
+
+    result = await service.set_own_display_name(10, "  Alice  ")
+
+    service.repository.set_display_name.assert_awaited_once_with(user, "Alice")
+    assert result == "Alice"
 
 
 async def test_authorization_service_maps_permission_to_bool():

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+from tortoise.exceptions import IntegrityError
+
 from alttprbot.services import AuthorizationService, UserService
 
 
@@ -56,6 +59,78 @@ async def test_link_merges_when_two_distinct_users_exist():
     service.repository.merge.assert_awaited_once_with(rtgg_user, discord_user)
     assert kept.display_name == "Alice"
     kept.save.assert_awaited_once()
+
+
+async def test_unlink_racetime_account_clears_link():
+    service = UserService()
+    service.repository = AsyncMock()
+    linked_user = MagicMock(rtgg_id="rt1")
+    service.repository.get_by_discord_id.return_value = linked_user
+
+    await service.unlink_racetime_account(10)
+
+    service.repository.clear_racetime_link.assert_awaited_once_with(linked_user)
+
+
+async def test_unlink_racetime_account_raises_when_no_user():
+    service = UserService()
+    service.repository = AsyncMock()
+    service.repository.get_by_discord_id.return_value = None
+
+    with pytest.raises(ValueError):
+        await service.unlink_racetime_account(10)
+
+    service.repository.clear_racetime_link.assert_not_awaited()
+
+
+async def test_unlink_racetime_account_raises_when_not_linked():
+    service = UserService()
+    service.repository = AsyncMock()
+    service.repository.get_by_discord_id.return_value = MagicMock(rtgg_id=None)
+
+    with pytest.raises(ValueError):
+        await service.unlink_racetime_account(10)
+
+    service.repository.clear_racetime_link.assert_not_awaited()
+
+
+async def test_update_display_name_rejects_empty():
+    service = UserService()
+    service.repository = AsyncMock()
+
+    with pytest.raises(ValueError):
+        await service.update_display_name(MagicMock(), "   ")
+
+    service.repository.set_display_name.assert_not_awaited()
+
+
+async def test_update_display_name_rejects_too_long():
+    service = UserService()
+    service.repository = AsyncMock()
+
+    with pytest.raises(ValueError):
+        await service.update_display_name(MagicMock(), "x" * 33)
+
+    service.repository.set_display_name.assert_not_awaited()
+
+
+async def test_update_display_name_strips_and_saves():
+    service = UserService()
+    service.repository = AsyncMock()
+    user = MagicMock()
+
+    await service.update_display_name(user, "  Alice  ")
+
+    service.repository.set_display_name.assert_awaited_once_with(user, "Alice")
+
+
+async def test_update_display_name_raises_on_duplicate():
+    service = UserService()
+    service.repository = AsyncMock()
+    service.repository.set_display_name.side_effect = IntegrityError()
+
+    with pytest.raises(ValueError):
+        await service.update_display_name(MagicMock(), "Alice")
 
 
 async def test_authorization_service_maps_permission_to_bool():


### PR DESCRIPTION
## Summary

Adds user profile management features to the web interface, allowing users to set a custom display name, view linked account status, and unlink their RaceTime.gg account. Includes backend service methods, API endpoints, and a redesigned profile UI.

## Key Changes

**Backend Service Layer (`alttprbot/services/user_service.py`)**
- Added `_validate_display_name()` static method with validation rules (1–32 chars, non-empty after trim)
- Added `set_own_display_name()` to validate and persist user-chosen display names, creating the user row if needed
- Added `get_account_summary()` to return linked-account state (Discord, RaceTime, Twitch) for the profile page
- Added `unlink_racetime_account()` to clear a user's RaceTime.gg link
- Modified `link_racetime_account()` to preserve existing display names instead of overwriting them; treats the Discord username as a fallback only when the user has no name yet; gracefully handles `IntegrityError` if the fallback name collides

**Repository Layer (`alttprbot/repositories/user_repository.py`)**
- Added `clear_racetime_link()` to null out `rtgg_id` and `rtgg_access_token`

**Web API (`alttprbot/presentation/web/blueprints/profile.py` — new file)**
- Added `POST /api/me/display-name` endpoint to update display name with validation
- Added `POST /api/me/racetime/unlink` endpoint to unlink RaceTime account
- Both endpoints require authorization and return error details on validation failure

**Web Backend (`alttprbot/presentation/web/web.py`)**
- Updated `GET /api/me` to include `display_name` and `linked_accounts` in the response
- Registered the new `profile_blueprint`

**Frontend (`alttprbot/presentation/web/spa/src/`)**
- Updated `useMe.ts` hook to include `display_name` and `linked_accounts` in `MeData` type
- Added `meQueryKey` export for query invalidation
- Refactored `ProfilePage.tsx`:
  - Added `postJson()` helper for consistent fetch/parse/error handling
  - Added `DisplayNameSection` component with input validation, save button, and success/error feedback
  - Added `LinkedAccountsSection` component showing Discord, RaceTime, and Twitch account status with unlink confirmation
  - Replaced static "RaceTime Verification" section with dynamic linked-accounts UI
  - Added query invalidation on successful updates to keep profile in sync
- Added styling for linked-account rows and hints in `profile.css`

**Tests**
- Added comprehensive unit tests for new service methods (display name validation, account summary, unlink, merge/upsert behavior with existing names)
- Added integration tests for the new API endpoints (`test_profile_blueprint.py`)

## Notable Implementation Details

- **Display name preservation:** The `link_racetime_account()` method now checks if a user already has a display name before applying the fallback. This prevents overwriting user-chosen names during RaceTime linking.
- **Graceful collision handling:** If the fallback display name collides with an existing name during a merge, the error is logged and swallowed rather than failing the entire link operation.
- **Validation before DB access:** `set_own_display_name()` validates input before any repository calls, preventing junk user rows from being created for invalid input.
- **Query invalidation:** The profile page uses React Query's `invalidateQueries()` to refresh the user summary after successful updates, ensuring the UI stays in sync with the server.

https://claude.ai/code/session_018BSLEike6fUtuQmdax1TLa