### PR TITLE
Fix high-severity SonarQube findings (Phase 1)

### DIFF
--- a/alttprbot/presentation/api/blueprints/racetime.py
+++ b/alttprbot/presentation/api/blueprints/racetime.py
@@ -74,7 +74,7 @@ async def bot_command():
                 'can_moderate': True,
             },
             'bot': False,
-            'posted_at': datetime.datetime.utcnow().isoformat(),
+            'posted_at': datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat(),
             'message': cmd,
             'message_plain': cmd,
             'highlight': False,
@@ -84,7 +84,7 @@ async def bot_command():
             'delay': 0
         },
         'type': 'message.chat',
-        'date': datetime.datetime.utcnow().isoformat(),
+        'date': datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat(),
     }
 
     await racetime_handler.send_message(f"Executing command from API request: {cmd}")

--- a/alttprbot/presentation/discord/cogs/racer_verification.py
+++ b/alttprbot/presentation/discord/cogs/racer_verification.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 from typing import List
 from io import StringIO
 import asyncio
@@ -285,7 +286,7 @@ async def get_racetime_count(racetime_id, category_slugs=None, days=365, max_cou
                              if x['category']['slug'] in category_slugs
                              and x['status']['value'] == 'finished'
                              and tz_aware_greater_than(isodate.parse_datetime(x['opened_at']),
-                                                       datetime.utcnow() - timedelta(days=days))
+                                                       datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days))
                              ]
 
             count += len(filtered_data)

--- a/alttprbot/presentation/discord/cogs/racetime_tools.py
+++ b/alttprbot/presentation/discord/cogs/racetime_tools.py
@@ -16,11 +16,11 @@ class RacetimeTools(commands.Cog):
 
     @commands.Cog.listener()
     async def on_racetime_open(self, handler, data):
-        pass
+        pass  # no-op: this racetime event needs no handling
 
     @commands.Cog.listener()
     async def on_racetime_invitational(self, handler, data):
-        pass
+        pass  # no-op: this racetime event needs no handling
 
     @commands.Cog.listener()
     async def on_racetime_in_progress(self, handler, data):
@@ -29,11 +29,11 @@ class RacetimeTools(commands.Cog):
 
     @commands.Cog.listener()
     async def on_racetime_cancelled(self, handler, data):
-        pass
+        pass  # no-op: this racetime event needs no handling
 
     @commands.Cog.listener()
     async def on_racetime_finished(self, handler, data):
-        pass
+        pass  # no-op: this racetime event needs no handling
 
     async def watchlisted_players(self, handler):
         entrant_ids = [a['user']['id'] for a in handler.data['entrants']]

--- a/alttprbot/presentation/racetime/handlers/core.py
+++ b/alttprbot/presentation/racetime/handlers/core.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import math
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import groupby
 
 import discord.utils
@@ -233,17 +233,17 @@ class SahasrahBotCoreHandler(RaceHandler):
             await self.tournament.on_race_pending()
 
     async def status_open(self):
-        pass
+        pass  # no-op: default status hook, overridden by subclasses
 
     async def status_invitational(self):
-        pass
+        pass  # no-op: default status hook, overridden by subclasses
 
     async def status_finished(self):
         if self.konot:
             await self.konot.create_next_room()
 
     async def race_data_hook(self):
-        pass
+        pass  # no-op: default hook, overridden by subclasses that need race data
 
     async def intro(self):
         """
@@ -359,7 +359,7 @@ class SahasrahBotCoreHandler(RaceHandler):
             await self.send_message("You do not have permission to override the stream requirement for this category.  Please contact a category owner if you need this to be changed.")
             return
 
-        if whitelisted_user.expires is not None and whitelisted_user.expires < datetime.utcnow():
+        if whitelisted_user.expires is not None and whitelisted_user.expires < datetime.now(timezone.utc).replace(tzinfo=None):
             await self.send_message("Your streaming exemption has expired.  Please contact a category owner if you need this to be renewed.")
             return
 

--- a/alttprbot/presentation/racetime/handlers/sgl.py
+++ b/alttprbot/presentation/racetime/handlers/sgl.py
@@ -3,7 +3,7 @@ from .core import SahasrahBotCoreHandler
 
 class GameHandler(SahasrahBotCoreHandler):
     async def intro(self):
-        pass
+        pass  # no-op: this category posts no intro message
 
     async def ex_help(self, args, message):
         await self.send_message("I have no commands for this category.")

--- a/alttprbot/presentation/racetime/handlers/smwhacks.py
+++ b/alttprbot/presentation/racetime/handlers/smwhacks.py
@@ -3,7 +3,7 @@ from .core import SahasrahBotCoreHandler
 
 class GameHandler(SahasrahBotCoreHandler):
     async def intro(self):
-        pass
+        pass  # no-op: this category posts no intro message
 
     async def ex_help(self, args, message):
         await self.send_message("I have no commands for this category.")

--- a/alttprbot/presentation/racetime/handlers/twwr.py
+++ b/alttprbot/presentation/racetime/handlers/twwr.py
@@ -3,19 +3,19 @@ from .core import SahasrahBotCoreHandler
 
 class GameHandler(SahasrahBotCoreHandler):
     async def intro(self):
-        pass
+        pass  # no-op: this category posts no intro message
 
     async def ex_help(self, args, message):
-        pass
+        pass  # no-op: command intentionally disabled for this category
 
     async def ex_lock(self, args, message):
-        pass
+        pass  # no-op: command intentionally disabled for this category
 
     async def ex_unlock(self, args, message):
-        pass
+        pass  # no-op: command intentionally disabled for this category
 
     async def ex_cancel(self, args, message):
-        pass
+        pass  # no-op: command intentionally disabled for this category
 
     async def ex_tournamentrace(self, args, message):
-        pass
+        pass  # no-op: command intentionally disabled for this category

--- a/alttprbot/presentation/web/oauth_client.py
+++ b/alttprbot/presentation/web/oauth_client.py
@@ -184,7 +184,7 @@ class AuthlibDiscordOAuth:
             return flow_data
             
         except OAuth2Error as e:
-            logger.error("auth_callback_failed", extra={
+            logger.exception("auth_callback_failed", extra={
                 'error': str(e)
             })
             raise
@@ -221,7 +221,7 @@ class AuthlibDiscordOAuth:
             return DiscordUser(user_data)
             
         except Exception as e:
-            logger.error("auth_fetch_user_failed", extra={
+            logger.exception("auth_fetch_user_failed", extra={
                 'error': str(e)
             })
             raise Unauthorized("Failed to fetch user") from e

--- a/alttprbot/presentation/web/spa/src/theme/ThemeProvider.tsx
+++ b/alttprbot/presentation/web/spa/src/theme/ThemeProvider.tsx
@@ -25,7 +25,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<Theme>(readInitial);
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme);
+    document.documentElement.dataset.theme = theme;
     try {
       localStorage.setItem(STORAGE_KEY, theme);
     } catch {

--- a/alttprbot/services/audit_messages_service.py
+++ b/alttprbot/services/audit_messages_service.py
@@ -16,7 +16,7 @@ class AuditMessagesService:
         self.repository = AuditMessagesRepository()
 
     async def clean_old_messages(self, days: int = 30) -> int:
-        cutoff = datetime.datetime.utcnow() - datetime.timedelta(days=days)
+        cutoff = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None) - datetime.timedelta(days=days)
         return await self.repository.delete_older_than(cutoff)
 
     async def list_user_history(self, guild_id: int, user_id: int, limit: int) -> List[Dict[str, Any]]:

--- a/alttprbot/services/seedgen/randomizer/alttprdoor.py
+++ b/alttprbot/services/seedgen/randomizer/alttprdoor.py
@@ -8,6 +8,7 @@ import re
 import string
 import tempfile
 import sys
+from pathlib import Path
 
 import aioboto3
 import aiofiles
@@ -55,8 +56,7 @@ class AlttprDoor():
             self.settings['names'] = ""
             self.settings['race'] = not self.spoilers
 
-            with open(settings_file_path, "w") as f:
-                json.dump(self.settings, f)
+            await asyncio.to_thread(Path(settings_file_path).write_text, json.dumps(self.settings))
 
             attempts = 0
             try:

--- a/alttprbot/services/seedgen/randomizer/ctjets.py
+++ b/alttprbot/services/seedgen/randomizer/ctjets.py
@@ -1,3 +1,6 @@
+import asyncio
+from pathlib import Path
+
 import aiohttp
 from bs4 import BeautifulSoup
 
@@ -20,8 +23,8 @@ async def roll_ctjets(settings: dict, version: str = '3_1_0'):
         for key, val in settings.items():
             formdata.add_field(key, val)
 
-        with open('/opt/data/chronotrigger.sfc', 'rb') as rom:
-            formdata.add_field('rom_file', rom.read(), filename=None)
+        rom_bytes = await asyncio.to_thread(Path('/opt/data/chronotrigger.sfc').read_bytes)
+        formdata.add_field('rom_file', rom_bytes, filename=None)
 
         headers = {
             'Referer': f'https://ctjot.com/{version}/options/',

--- a/alttprbot/services/seedgen/randomizer/smdash.py
+++ b/alttprbot/services/seedgen/randomizer/smdash.py
@@ -10,7 +10,7 @@ async def create_smdash(mode="classic_mm", spoiler=False):
         route = f'https://www.dashrando.net/generate/{mode}?race=1'
         if spoiler:
             route += '&spoiler=1'
-        async with session.get(route, ssl=ssl.SSLContext(protocol=ssl.PROTOCOL_TLSv1_2),
+        async with session.get(route, ssl=ssl.create_default_context(),
                                allow_redirects=False) as resp:
             msg = await resp.text()
             if resp.status == 307:
@@ -25,12 +25,12 @@ async def get_smdash_presets():
     try:
         async with aiohttp.ClientSession() as session:
             route = f'https://www.dashrando.net/api/presets'
-            async with session.get(route, ssl=ssl.SSLContext(protocol=ssl.PROTOCOL_TLSv1_2),
+            async with session.get(route, ssl=ssl.create_default_context(),
                                 allow_redirects=False) as resp:
                 obj = await resp.json()
                 presets = []
                 for p in obj['data']:
                     presets.append(p['tags'][0])
                 return presets
-    except:
+    except Exception:
         return ['classic', 'recall', '2017_mm', 'chozo_bozo', 'sgl23', 'surprise_surprise']

--- a/alttprbot/services/spoiler_race_service.py
+++ b/alttprbot/services/spoiler_race_service.py
@@ -4,7 +4,7 @@ Owns the spoiler-race record lifecycle (lookup, schedule, mark started, delete).
 The countdown/timer orchestration stays in the RaceTime handler (presentation).
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from alttprbot import models
@@ -25,7 +25,7 @@ class SpoilerRaceService:
         return spoiler_race
 
     async def mark_started(self, spoiler_race: models.SpoilerRaces) -> None:
-        await self.repository.mark_started(spoiler_race, datetime.utcnow())
+        await self.repository.mark_started(spoiler_race, datetime.now(timezone.utc).replace(tzinfo=None))
 
     async def delete(self, spoiler_race: models.SpoilerRaces) -> None:
         await self.repository.delete_instance(spoiler_race)

--- a/alttprbot/services/tournament/core.py
+++ b/alttprbot/services/tournament/core.py
@@ -178,25 +178,25 @@ class TournamentOrchestrator:
 
     # --- business hooks (overridden per event; no-op base) ---
     async def roll(self):
-        pass
+        pass  # no-op base hook; overridden per tournament
 
     async def create_embeds(self):
-        pass
+        pass  # no-op base hook; overridden per tournament
 
     async def send_room_welcome(self):
-        pass
+        pass  # no-op base hook; overridden per tournament
 
     async def on_room_creation(self):
-        pass
+        pass  # no-op base hook; overridden per tournament
 
     async def on_room_resume(self):
-        pass
+        pass  # no-op base hook; overridden per tournament
 
     async def on_race_start(self):
-        pass
+        pass  # no-op base hook; overridden per tournament
 
     async def on_race_pending(self):
-        pass
+        pass  # no-op base hook; overridden per tournament
 
     async def process_race(self, args, message) -> bool:
         """Handle the ``!tournamentrace`` seed-roll for this room.

--- a/alttprbot/util/telemetry.py
+++ b/alttprbot/util/telemetry.py
@@ -12,7 +12,7 @@ import asyncio
 import hashlib
 import logging
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Optional, Protocol
 from collections import deque
 
@@ -52,8 +52,8 @@ class TelemetryEvent:
     sample_rate: float = 1.0
     
     # Computed fields (not in constructor)
-    created_at: datetime = field(default_factory=datetime.utcnow)
-    day_bucket: date = field(default_factory=lambda: datetime.utcnow().date())
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None))
+    day_bucket: date = field(default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None).date())
     guild_hash: Optional[str] = field(default=None, init=False)
     
     def __post_init__(self):
@@ -194,7 +194,7 @@ class DatabaseTelemetryService:
                 
             except Exception as e:
                 # Fail-open: log error but don't crash
-                logger.error(f"Failed to flush telemetry events: {e}", exc_info=True)
+                logger.exception(f"Failed to flush telemetry events: {e}")
 
 
 # Global telemetry service instance

--- a/helpers/purge_old_telemetry.py
+++ b/helpers/purge_old_telemetry.py
@@ -8,7 +8,7 @@ Should be run as a scheduled task (e.g., daily cron job).
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 try:
     import config
@@ -32,7 +32,7 @@ async def purge_old_telemetry_events(retention_days: int = TELEMETRY_RETENTION_D
     
     Returns the number of events deleted.
     """
-    cutoff_date = datetime.utcnow() - timedelta(days=retention_days)
+    cutoff_date = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=retention_days)
     
     logger.info(f"Purging telemetry events older than {cutoff_date} ({retention_days} days)")
     
@@ -95,7 +95,7 @@ async def main():
         logger.info("\nPurge complete!")
         
     except Exception as e:
-        logger.error(f"Purge failed: {e}", exc_info=True)
+        logger.exception(f"Purge failed: {e}")
         raise
     finally:
         await Tortoise.close_connections()

--- a/helpers/telemetry_report.py
+++ b/helpers/telemetry_report.py
@@ -7,7 +7,7 @@ Generates usage reports from telemetry data for operators.
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Dict, Any
 
 from alttprbot import models
@@ -27,7 +27,7 @@ async def get_daily_feature_usage(days: int = 7) -> List[Dict[str, Any]]:
     
     Returns aggregated counts by day, surface, feature, and action.
     """
-    cutoff_date = datetime.utcnow() - timedelta(days=days)
+    cutoff_date = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
     
     results = await models.TelemetryEvent.filter(
         created_at__gte=cutoff_date
@@ -42,7 +42,7 @@ async def get_success_failure_rates(days: int = 7) -> List[Dict[str, Any]]:
     """
     Get success vs failure rates by feature and provider.
     """
-    cutoff_date = datetime.utcnow() - timedelta(days=days)
+    cutoff_date = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
     
     results = await models.TelemetryEvent.filter(
         created_at__gte=cutoff_date,
@@ -60,7 +60,7 @@ async def get_active_guild_count(days: int = 7) -> int:
     
     Note: This is an approximation due to hashing.
     """
-    cutoff_date = datetime.utcnow() - timedelta(days=days)
+    cutoff_date = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
     
     guilds = await models.TelemetryEvent.filter(
         created_at__gte=cutoff_date,
@@ -72,7 +72,7 @@ async def get_active_guild_count(days: int = 7) -> int:
 
 async def get_top_features(days: int = 7, limit: int = 10) -> List[Dict[str, Any]]:
     """Get the most-used features."""
-    cutoff_date = datetime.utcnow() - timedelta(days=days)
+    cutoff_date = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
     
     results = await models.TelemetryEvent.filter(
         created_at__gte=cutoff_date
@@ -90,7 +90,7 @@ async def print_report(days: int = 7):
     logger.info("=" * 80)
     
     # Total events
-    cutoff_date = datetime.utcnow() - timedelta(days=days)
+    cutoff_date = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
     total_events = await models.TelemetryEvent.filter(
         created_at__gte=cutoff_date
     ).count()
@@ -187,7 +187,7 @@ async def main():
         await print_report(days=days)
         
     except Exception as e:
-        logger.error(f"Report generation failed: {e}", exc_info=True)
+        logger.exception(f"Report generation failed: {e}")
         raise
     finally:
         await Tortoise.close_connections()

--- a/utils/enemizer/install.sh
+++ b/utils/enemizer/install.sh
@@ -1,13 +1,14 @@
+#!/usr/bin/env bash
 PLATFORM=$(uname -s)
 
 # if we're on linux, download the linux version of the enemizer
-if [ "$PLATFORM" = "Linux" ]; then
+if [[ "$PLATFORM" = "Linux" ]]; then
     curl https://github.com/tcprescott/Enimizer/releases/download/2mb-rom/ubuntu.16.04-x64.tar.gz -o ubuntu.16.04-x64.tar.gz -L
     mkdir ubuntu.16.04-x64
     tar -xzf ubuntu.16.04-x64.tar.gz -C ubuntu.16.04-x64
 fi
 
-if [ "$PLATFORM" = "Darwin" ]; then
+if [[ "$PLATFORM" = "Darwin" ]]; then
     curl https://github.com/tcprescott/Enimizer/releases/download/2mb-rom/osx.10.12-x64.tar.gz -o osx.10.12-x64.tar.gz -L
     mkdir osx.10.12-x64
     tar -xzf osx.10.12-x64.tar.gz -C osx.10.12-x64


### PR DESCRIPTION
## Context

SonarQube project `tcprescott_sahasrahbot` had **159 open HIGH/BLOCKER findings**. This PR is **Phase 1** of a phased burn-down: the genuine security, reliability, and async-correctness bugs plus low-risk maintainability cleanups. Idiomatic/false-positive findings were resolved in SonarQube rather than churned in code.

## What changed (~28 findings fixed in code)

- **Security** — `smdash.py`: `ssl.SSLContext(PROTOCOL_TLSv1_2)` → `ssl.create_default_context()` (restores cert + hostname verification); bare `except:` → `except Exception:`.
- **Reliability** — deprecated `datetime.utcnow()` → `datetime.now(timezone.utc).replace(tzinfo=None)` across 13 sites, **preserving naive-UTC** because Tortoise runs `use_tz=False` (a blind swap to tz-aware would throw on ORM comparisons).
- **Async correctness** — blocking `open()` wrapped in `asyncio.to_thread(...)` (`ctjets`, `alttprdoor`).
- **Trivial** — `logger.error` → `logger.exception` in except blocks (×5); `[ ]` → `[[ ]]` + bash shebang in `enemizer/install.sh`; `setAttribute('data-theme')` → `dataset.theme`.
- **Empty stubs** — one-line "why empty" comments on 22 intentional override no-ops.

## Resolved in SonarQube (not code)

- 33 idiomatic `void` fire-and-forget calls (S3735) — **Accepted** (no ESLint `no-floating-promises` rule enforces awaiting).
- 2 dev-helper path findings (S8707) — **Accepted** (trusted-maintainer local tool).
- 1 weak-TLS ref (S4423) left untouched — that line is already `create_default_context()`, so the rescan closes it as *Fixed*.

## Verification

- `pytest` — **519 passed / 0 failed**
- `lint-imports` — **5/5 contracts kept**
- smdash smoke test — returned the **live** preset list over verified TLS (not the fallback)
- config validator imports clean (only fails on absent secrets in this env)

**Not run:** SPA `npm run build` — `node_modules` not installed; the one-line `dataset.theme` change is provably type-safe and behavior-identical.

## Deferred

- **Phase 2** — 49 duplicate-literal → constants (S1192)
- **Phase 3** — 24 cognitive-complexity refactors (S3776)

🤖 Generated with [Claude Code](https://claude.com/claude-code)